### PR TITLE
chore: Dependabotの追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## 概要
依存関係の更新を自動化するために Dependabot を導入しました。

## 設定内容 (.github/dependabot.yml)
- **pip**: 週次 (weekly) で更新チェック
- **github-actions**: 月次 (monthly) で更新チェック