### PR TITLE
feat: コンテンツ分析精度向上とタイトル除外機能 (Fixes #18)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,7 @@
 import os
 
 IGNORE_FILE_PATH = "ignore_list.txt"
+IGNORE_TITLES_PATH = "ignore_titles.txt"
 
 
 def load_ignore_list():
@@ -34,3 +35,36 @@ def remove_domain(domain):
     if domain in current:
         current.remove(domain)
         save_ignore_list(current)
+
+
+def load_ignore_titles():
+    """Loads ignore titles from file. Returns a list of keywords."""
+    if not os.path.exists(IGNORE_TITLES_PATH):
+        return []
+
+    with open(IGNORE_TITLES_PATH, "r") as f:
+        lines = f.readlines()
+
+    return [line.strip() for line in lines if line.strip()]
+
+
+def save_ignore_titles(titles_list):
+    """Saves ignore titles to file."""
+    with open(IGNORE_TITLES_PATH, "w") as f:
+        for title in sorted(titles_list):
+            f.write(f"{title}\n")
+
+
+def add_ignore_title(title):
+    """Adds a title keyword to the ignore list."""
+    current = set(load_ignore_titles())
+    current.add(title)
+    save_ignore_titles(list(current))
+
+
+def remove_ignore_title(title):
+    """Removes a title keyword from the ignore list."""
+    current = set(load_ignore_titles())
+    if title in current:
+        current.remove(title)
+        save_ignore_titles(list(current))


### PR DESCRIPTION
## 概要
コンテンツ分析（Top Pages）の精度を高めるため、データのクレンジング処理を強化し、タイトルによる除外機能を実装しました。

## 変更点
- **ETL処理の強化 (`src/etl.py`):**
    - **空白タイトルの除外:** タイトルがないレコードを分析対象外にしました。
    - **URLパラメータ除去:** `?` 以降のクエリパラメータを削除し、同じページとして集計するようにしました。
    - **タイトル除外フィルタ:** 指定したキーワードをタイトルに含むレコードを除外するフィルタを実装しました。
- **設定機能の拡張 (`src/config.py`):**
    - タイトル除外リストの読み書き機能を追加しました。
- **UI拡張 (`app.py`):**
    - サイドバーの「Filters」セクションをタブ化し、「Domains」と「Titles」の両方のIgnore Listを管理できるようにしました。

## 動作確認
- サイドバーの「Ignore Management > Titles」タブでキーワードを追加し、データがリロードされた後、該当キーワードを含むページがチャートやリストから消えることを確認。
- パラメータ付きのURLが、パラメータなしのURLと同一ページとしてカウントされることを確認。